### PR TITLE
remove djcelery from INSTALLED_APPS before routing

### DIFF
--- a/threadless_router/celery/tasks.py
+++ b/threadless_router/celery/tasks.py
@@ -1,4 +1,5 @@
 import datetime
+from django.conf import settings
 
 from rapidsms.models import Connection, Backend
 from rapidsms.messages import IncomingMessage
@@ -14,7 +15,14 @@ class IncomingTask(Task):
         backend, _ = Backend.objects.get_or_create(name=backend_name)
         connection, _ = backend.connection_set.get_or_create(identity=identity)
         message = IncomingMessage(connection, text, datetime.datetime.now())
-        router = Router()
+        # remove the djcelery app from the INSTALLED_APPS list
+        # to prevent the router from attempting to process messages
+        # through the app module of djcelery
+        try:
+            settings.INSTALLED_APPS.remove('djcelery')
+        except ValueError:
+            pass
+        router = Router(apps=settings.INSTALLED_APPS)
         response = router.incoming(message)
 
 

--- a/threadless_router/celery/tasks.py
+++ b/threadless_router/celery/tasks.py
@@ -14,9 +14,6 @@ class IncomingTask(Task):
         backend, _ = Backend.objects.get_or_create(name=backend_name)
         connection, _ = backend.connection_set.get_or_create(identity=identity)
         message = IncomingMessage(connection, text, datetime.datetime.now())
-        # remove the djcelery app from the INSTALLED_APPS list
-        # to prevent the router from attempting to process messages
-        # through the app module of djcelery
         router = Router()
         response = router.incoming(message)
 

--- a/threadless_router/celery/tasks.py
+++ b/threadless_router/celery/tasks.py
@@ -1,7 +1,6 @@
 import datetime
-from django.conf import settings
 
-from rapidsms.models import Connection, Backend
+from rapidsms.models import Backend
 from rapidsms.messages import IncomingMessage
 
 from threadless_router.router import Router
@@ -18,11 +17,7 @@ class IncomingTask(Task):
         # remove the djcelery app from the INSTALLED_APPS list
         # to prevent the router from attempting to process messages
         # through the app module of djcelery
-        try:
-            settings.INSTALLED_APPS.remove('djcelery')
-        except ValueError:
-            pass
-        router = Router(apps=settings.INSTALLED_APPS)
+        router = Router()
         response = router.incoming(message)
 
 

--- a/threadless_router/router.py
+++ b/threadless_router/router.py
@@ -47,10 +47,14 @@ class Router(LegacyRouter):
         the router is started. Return the backend instance.
         """
         if not inspect.isclass(module_name):
-            cls = BackendBase.find(module_name)
-            if cls is None: return None
-        else:
+            try:
+                cls = BackendBase.find(module_name)
+            except AttributeError:
+                cls = None
+        elif issubclass(module_name, BackendBase):
             cls = module_name
+        if not cls:
+            return None
         config = self._clean_backend_config(config or {})
         backend = cls(self, name, **config)
         self.backends[name] = backend
@@ -63,10 +67,14 @@ class Router(LegacyRouter):
         app instance.
         """
         if not inspect.isclass(module_name):
-            cls = AppBase.find(module_name)
-            if cls is None: return None
-        else:
+            try:
+                cls = AppBase.find(module_name)
+            except AttributeError:
+                cls = None
+        elif issubclass(module_name, AppBase):
             cls = module_name
+        if not cls:
+            return None
         app = cls(self)
         self.apps.append(app)
         return app


### PR DESCRIPTION
Removes djcelery from INSTALLED_APPS before starting the router
to prevent processing the djcelery app module as a RapidSMS app.

This is only needed when using django-celery and the Async Task Queue module of the threadless router.
