### PR TITLE
Maintain send method signature

### DIFF
--- a/threadless_router/backends/httptester/backend.py
+++ b/threadless_router/backends/httptester/backend.py
@@ -8,6 +8,7 @@ class HttpTesterCacheBackend(BackendBase):
 
     def send(self, msg):
         store_message('out', msg.connection.identity, msg.text)
+        return True
 
     def start(self):
         """ Override BackendBase.start(), which never returns """


### PR DESCRIPTION
It is important for the send method of the HTTPTester to return True
otherwise you get weird hard to debug errors when some other calling
code expects True to be returned when a message is sent.
